### PR TITLE
SystemUIGoogle: Add burn-in protection constructor

### DIFF
--- a/SystemUIGoogle/src/com/google/android/systemui/statusbar/phone/CentralSurfacesGoogle.java
+++ b/SystemUIGoogle/src/com/google/android/systemui/statusbar/phone/CentralSurfacesGoogle.java
@@ -119,6 +119,7 @@ import com.android.systemui.statusbar.phone.StatusBarSignalPolicy;
 import com.android.systemui.statusbar.phone.StatusBarTouchableRegionManager;
 import com.android.systemui.statusbar.phone.ongoingcall.OngoingCallController;
 import com.android.systemui.statusbar.policy.BatteryController;
+import com.android.systemui.statusbar.policy.BurnInProtectionController;
 import com.android.systemui.statusbar.policy.ConfigurationController;
 import com.android.systemui.statusbar.policy.DeviceProvisionedController;
 import com.android.systemui.statusbar.policy.ExtensionController;
@@ -283,6 +284,7 @@ public class CentralSurfacesGoogle extends CentralSurfacesImpl {
             GlanceableHubContainerController glanceableHubContainerController,
             EmergencyGestureIntentFactory emergencyGestureIntentFactory,
             SysUiState sysUiState,
+            BurnInProtectionController burnInProtectionController,
             Optional<ReverseChargingViewController> reverseChargingViewControllerOptional,
             WallpaperNotifier wallpaperNotifier,
             SmartSpaceController smartSpaceController,
@@ -306,7 +308,7 @@ public class CentralSurfacesGoogle extends CentralSurfacesImpl {
                 keyguardUnlockAnimationController, delayableExecutor, messageRouter, wallpaperManager, startingSurfaceOptional, activityTransitionAnimator,
                 deviceStateManager, wiredChargingRippleController, dreamManager, cameraLauncherLazy, lightRevealScrimViewModelLazy, lightRevealScrim,
                 alternateBouncerInteractor, userTracker, fingerprintManager, activityStarter, tunerService, brightnessMirrorShowingInteractor,
-                glanceableHubContainerController, emergencyGestureIntentFactory, sysUiState);
+                glanceableHubContainerController, emergencyGestureIntentFactory, sysUiState, burnInProtectionController);
         mContext = context;
         mBatteryStateChangeCallback = new BatteryController.BatteryStateChangeCallback() {
             @Override


### PR DESCRIPTION
Synchronize with `frameworks/base`